### PR TITLE
修复了:先下拉刷新完成看到的不是"下拉刷新"而是"刷新完成"的问题.

### DIFF
--- a/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicHeader.java
+++ b/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicHeader.java
@@ -127,7 +127,8 @@ public class ClassicHeader extends RelativeLayout implements SmartSwipeRefresh.S
 
     @Override
     public void onReset() {
-
+        //修复了:先下拉刷新完成(此时显示为刷新完成),然后调用 startRefresh 时,看到的不是"下拉刷新"而是"刷新完成"的问题.
+        setText(com.billy.android.swipe.R.string.ssr_header_pulling);
     }
 
     @Override


### PR DESCRIPTION
问题复现步骤:
1. 先下拉刷新完成(此时显示为刷新完成),
2. 然后调用 startRefresh 时,看到的不是"下拉刷新"而是"刷新完成"