### PR TITLE
修复了上拉加载始终显示"已全部加载完成"的问题.

### DIFF
--- a/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicFooter.java
+++ b/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicFooter.java
@@ -66,6 +66,8 @@ public class ClassicFooter extends ClassicHeader implements SmartSwipeRefresh.Sm
     @Override
     public void setNoMoreData(boolean noMoreData) {
         this.mNoMoreData = noMoreData;
-        setText(R.string.ssr_footer_no_more_data);
+        //修复了上拉加载始终显示"已全部加载完成"的问题.
+        if (noMoreData)
+            setText(R.string.ssr_footer_no_more_data);
     }
 }


### PR DESCRIPTION
问题复现步骤:
1. 上拉加载数据
2. 观察显示的提示文本
3. 上拉加载完全部数据后
4. 再观察显示的提示文本.